### PR TITLE
Aktualizace LXC balíčků přes updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Nejprve je třeba mít aktualizován Turris OS alespoň na verzi 3.0, tedy verzi
 
 Je třeba mít k dispozici vhodné úložiště pro kontejnery. Nejlepší je SSD, nebo HDD v SATA portu, stále dobré je totéž připojené přes USB. Když není jiného zbytí, lze použít buď SD kartu (v nativním slotu pod pamětí, či v USB), nebo obyčejný flash disk v USB. U flash disku, nebo SD karty je nutné počítat s možným brzkým opotřebením a pomalou odezvou. Interní NAND paměť Turrisu nelze použít už jen vzhledem ke kapacitě, dále proto, že po opotřebení nejde vyměnit.
 
+* Kontejnery nelze nainstalovat, pokud máte uložiště ve formátu FAT. Je potřeba použít například: btrfs, ext4 *
+
 ## Situace ohledně distribucí
 
 Vzhledem k architektuře procesu v Turrisu (1.0 a 1.1) je bohužel výběr linuxových distribucí poměrně dost omezený a to na:
@@ -18,7 +20,8 @@ Vzhledem k architektuře procesu v Turrisu (1.0 a 1.1) je bohužel výběr linux
 
 Jak OpenWRT, tak Turris OS v kontejneru mají jistě svá využití, nicméně nejzajímavější je poslední možnost, která je rozebrána dále.
 
-# Instalace prerekvizit
+
+# Instalace
 
 0. Aktualizace seznamu balíků
 
@@ -26,17 +29,20 @@ Jak OpenWRT, tak Turris OS v kontejneru mají jistě svá využití, nicméně n
     opkg update
     ```
     
-1. Instalace všech LXC balíků (ano, trochu overkill)
+1. Chceme, aby se nám o aktualizaci potřebných LXC balíčků staral přímo updater
+
+  Do souboru ```/etc/config/updater``` do sekce  ```config pkglists 'pkglists'```  vložíme:
 
      ```
-    opkg install liblxc luci-app-lxc lxc lxc-attach lxc-auto lxc-autostart lxc-cgroup lxc-checkconfig lxc-clone lxc-common lxc-config lxc-configs lxc-console lxc-create lxc-destroy lxc-device lxc-execute lxc-freeze lxc-hooks lxc-info lxc-init lxc-ls lxc-lua lxc-monitor lxc-monitord lxc-snapshot lxc-start lxc-stop lxc-templates lxc-unfreeze lxc-unshare lxc-user-nic lxc-usernsexec lxc-wait
+    list lists 'lxc' 
     ```
     
-2. Instalace dalších potřebných balíků
+2. Instalace potřebných balíků provede updater
 
     ```
-    opkg install kmod-veth vim wget
-    ```
+    updater.sh
+    ``` 
+Je nutné, aby byl zmigrovaný updater více zde: https://www.turris.cz/doc/cs/howto/updater_migration 
 
 # Instalace Debian PowerPCSPEPort
 
@@ -75,10 +81,23 @@ vim ./rootfs/etc/resolv.conf
 ```
 a upravíme adresu `127.0.0.1` na IP Turrise (výchozí `192.168.1.1`)
 
-Chceme, aby byl kontejner dostupný i v administračním rozhraní LuCI, odkud se dá také ovládat:
-```
-ln -s /mnt/disk/lxc-containers/debian1 /srv/lxc/debian1
-```
+
+**Pokud chceme, aby byl kontejner dostupný i v administračním rozhraní LuCI, odkud se dá také ovládat**
+
+Máme dvě možnosti buď:
+
+1. vytvoříme symlink
+
+     ```
+   ln -s /mnt/disk/lxc-containers/debian1 /srv/lxc/debian1 
+    ```
+    
+2. upravíme cestu ```lxc.lxcpath``` v souboru ```/etc/lxc/lxc.conf```
+     V mém případě to vypadá následovně:
+
+    ```
+    lxc.lxcpath = /mnt/disk/lxc-containers
+    ``` 
 
 Kontejner spustíme a připojíme se k jeho konzoli:
 ```
@@ -88,21 +107,28 @@ lxc-attach -n debian1
 
 ... a máme hotovo. Nyní můžeme využívat všechny dostupné _Debianí_ balíky, které jsou dostupné. (bohužel veliké množství balíků není k dispozici, ale je to dostatečné například k nainstalování aplikace Home Assistant pomocí pip3)
 
-# Automatické spuštění
-Pokud nemáme, tak 
-```
-opkg install lxc-auto
-```
+# Automatické spuštění kontejnerů
+V souboru `/etc/config/lxc-auto` jen nastavíme jméno našeho kontejneru.
 
-a v souboru `/etc/config/lxc-auto` jen nastavíme jméno našeho kontejneru.
+Podle: https://www.turris.cz/doc/cs/howto/lxc#spousteni_kontejneru_pri_startu
 
-# Poznámky
+... a nyní to je vše :-)
+
+###### Poznámky
 - Je možné provést debootstrap na PC a poté rootfs zkopírovat na Turris, což může být rychlejší. Zde se pracuje pouze na Turrisu kvůli jednoduchosti.
 - Je možné na úložišti používat btrfs, což lze využít k tomu, že jednou vytvořený kontejner může sloužit jako základ pro další, které se vytvoří instantně a šetří to místo.
+- Je možné místo textového editoru vim použít WinSCP
 
-# Zdroje
+###### Použití LXC kontejnerů:
+- Částečná izolace od hlavního systému a lepší migrovatelnost - klidně udělám factory reset Turrisu, aktualizuji jak chci, ale ten serverový kontejner je stále ve stejném stavu a po instalaci Turris OS stačí pouze pár příkazů pro opětovné integrování kontejneru do systému; tohle vidím jako velikou výhodu a už jsem změnil služby tak, že pod Turris OS jsou jen ty síťové věci a služby jsou v tom LXC Debianu
+- Öbecně tam jsou plné verze balíčků i základních knihoven a může být jednodušší používat balík v LXC Debianu, než se snažit kompilovat balík do OpenWRT
+- Webový server s PHP 7, což se může hodit, pokud chcete provozovat moderní aplikace, nebo chcete využít výkonový boost ve verzi 7
+- Snadno rozběháte Home Assistant v poslední verzi
+- Snadno rozběháte cokoliv, co se kompiluje, protože přímo na Turrisu máte GCC ... i když to chvíli potrvá
+
+
+###### Zdroje
 - https://www.root.cz/clanky/spusteni-openhab-serveru-na-routeru-turris/
 - https://wiki.debian.org/PowerPCSPEPort
 - https://l3net.wordpress.com/2013/11/03/debian-virtualization-lxc-debootstrap-filesystem/
 - https://wiki.debian.org/LXC
-- https://www.turris.cz/doc/cs/howto/lxc#spousteni_kontejneru_pri_startu

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Nejprve je třeba mít aktualizován Turris OS alespoň na verzi 3.0, tedy verzi
 
 Je třeba mít k dispozici vhodné úložiště pro kontejnery. Nejlepší je SSD, nebo HDD v SATA portu, stále dobré je totéž připojené přes USB. Když není jiného zbytí, lze použít buď SD kartu (v nativním slotu pod pamětí, či v USB), nebo obyčejný flash disk v USB. U flash disku, nebo SD karty je nutné počítat s možným brzkým opotřebením a pomalou odezvou. Interní NAND paměť Turrisu nelze použít už jen vzhledem ke kapacitě, dále proto, že po opotřebení nejde vyměnit.
 
-* Kontejnery nelze nainstalovat, pokud máte uložiště ve formátu FAT. Je potřeba použít například: btrfs, ext4 *
+* Kontejnery nelze nainstalovat, pokud máte uložiště ve formátu FAT. Je potřeba použít například: btrfs, ext4
 
 ## Situace ohledně distribucí
 
@@ -37,7 +37,7 @@ Jak OpenWRT, tak Turris OS v kontejneru mají jistě svá využití, nicméně n
     list lists 'lxc' 
     ```
     
-2. Instalace potřebných balíků provede updater
+2. Instalaci potřebných balíků provede updater
 
     ```
     updater.sh


### PR DESCRIPTION
- Instalace všech potřebných LXC balíčků přes updater a tím pádem neinstalujeme tolik "zbytečných" (ehm... přebytečných) balíčků
- Kontejnery viditelné i v LuCI
- Použití/využití LXC kontejnerů
- Přidání poznámky ohledně formátu FAT
- místo VIMu se kterým si začátečník nemusí poradit lze použít např. WinSCP

Čerpal jsem ( a zkopíroval jsem využití LXC kontejnerů od Vás @renekliment ) z fóra:
https://forum.turris.cz/t/lxc-kontejnery-na-turris-verze-1-x/2517
Tímto děkuji uživateli @Nones , že to sepsal ve fóru akorát jsem to upravil do čitelné formy.

Bylo by fajn to přidat i do [komunitní wiki](https://www.turris.cz/doc/cs/start) kvůli tomu jsem také přidal využití LXC kontejnerů.