### PR TITLE
Aktualizace návodu: instalace a aktuálnost LXC balíčků má na starost updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
-# Úvod
-
-## Turris OS 3.0+
-
-Nejprve je třeba mít aktualizován Turris OS alespoň na verzi 3.0, tedy verzi jádra _3.18.něco_.
+# LXC kontejnery pro Turris 1.x
 
 ## Úložiště
 
-Je třeba mít k dispozici vhodné úložiště pro kontejnery. Nejlepší je SSD, nebo HDD v SATA portu, stále dobré je totéž připojené přes USB. Když není jiného zbytí, lze použít buď SD kartu (v nativním slotu pod pamětí, či v USB), nebo obyčejný flash disk v USB. U flash disku, nebo SD karty je nutné počítat s možným brzkým opotřebením a pomalou odezvou. Interní NAND paměť Turrisu nelze použít už jen vzhledem ke kapacitě, dále proto, že po opotřebení nejde vyměnit.
+Je potřeba mít vhodné uložiště pro kontejnery.
+
+Nejlepší je SSD, nebo HDD v SATA portu, stále dobré je totéž připojené přes USB. 
+Když není jiného zbytí, lze použít buď SD kartu (v nativním slotu pod RAM nebo v USB čtečce), nebo obyčejný flash disk v USB. 
+
+U flash disku, nebo SD karty je nutné počítat s možným brzkým opotřebením a pomalou odezvou.
+
+**Interní NAND paměť Turrisu nelze použít už jen vzhledem ke kapacitě, dále proto, že po opotřebení nejde vyměnit.**
+
+Kontejnery nelze na instalovat na uložiště ve formátu FAT. Je tedy nutné použít např. btrfs, ext4 a jiné.
 
 ## Situace ohledně distribucí
 
-Vzhledem k architektuře procesu v Turrisu (1.0 a 1.1) je bohužel výběr linuxových distribucí poměrně dost omezený a to na:
+Vzhledem k architektuře procesoru v Turrisu (1.0 a 1.1) je bohužel výběr linuxových distribucí poměrně dost omezený a to na:
 
 - OpenWRT,
 - Turris OS, 
@@ -18,24 +23,31 @@ Vzhledem k architektuře procesu v Turrisu (1.0 a 1.1) je bohužel výběr linux
 
 Jak OpenWRT, tak Turris OS v kontejneru mají jistě svá využití, nicméně nejzajímavější je poslední možnost, která je rozebrána dále.
 
-# Instalace prerekvizit
+# Instalace LXC balíčků pomocí updateru
 
-0. Aktualizace seznamu balíků
-
-     ```
-    opkg update
-    ```
-    
-1. Instalace všech LXC balíků (ano, trochu overkill)
+1. Vložíme tento kód do souboru /etc/updater/user.lua
 
      ```
-    opkg install liblxc luci-app-lxc lxc lxc-attach lxc-auto lxc-autostart lxc-cgroup lxc-checkconfig lxc-clone lxc-common lxc-config lxc-configs lxc-console lxc-create lxc-destroy lxc-device lxc-execute lxc-freeze lxc-hooks lxc-info lxc-init lxc-ls lxc-lua lxc-monitor lxc-monitord lxc-snapshot lxc-start lxc-stop lxc-templates lxc-unfreeze lxc-unshare lxc-user-nic lxc-usernsexec lxc-wait
+    local script_options = {
+	security = "Remote",
+	ca = "file:///etc/ssl/updater.pem",
+	crl = "file:///tmp/crl.pem",
+	ocsp = false,
+	pubkey = { "file:///etc/updater/keys/release.pub" }
+     }
+     Script("userlist-lxc", "https://api.turris.cz/updater-defs/" .. turris_version ..  "/turris/userlists/lxc.lua", script_options)
+     ```
+    
+2. Spustíme updater.sh, aby nám nainstaloval balíčky LXC
+
+     ```
+     updater.sh
     ```
     
-2. Instalace dalších potřebných balíků
+3. Volitelná instalace textového editoru **vim** (pro upravování souborů lze také použít [WinSCP](https://winscp.net).
 
     ```
-    opkg install kmod-veth vim wget
+    opkg install vim 
     ```
 
 # Instalace Debian PowerPCSPEPort
@@ -80,6 +92,15 @@ Chceme, aby byl kontejner dostupný i v administračním rozhraní LuCI, odkud s
 ln -s /mnt/disk/lxc-containers/debian1 /srv/lxc/debian1
 ```
 
+Pokud chceme, aby byly kontejnery dostupné i v LuCI, kde s nimi můžeme manipulovat, tak jsou dvě možnosti:
+
+1. Vytvoříme symlink
+```
+ln -s /mnt/disk/lxc-containers/debian1 /srv/lxc/debian1
+```
+2. Upravíme cestu lxc.lxcpath v souboru /etc/lxc/lxc.conf
+
+
 Kontejner spustíme a připojíme se k jeho konzoli:
 ```
 lxc-start -n debian1
@@ -89,12 +110,33 @@ lxc-attach -n debian1
 ... a máme hotovo. Nyní můžeme využívat všechny dostupné _Debianí_ balíky, které jsou dostupné. (bohužel veliké množství balíků není k dispozici, ale je to dostatečné například k nainstalování aplikace Home Assistant pomocí pip3)
 
 # Automatické spuštění
-Pokud nemáme, tak 
+
+V souboru **/etc/config/lxc-auto** nastavíme jméno našeho kontejneru podle [oficiální dokumentace]( https://www.turris.cz/doc/cs/howto/lxc#spousteni_kontejneru_pri_startu).
+
+## Známé chyby
+
+Před pár dny se odstranil balík **apt-transport-https**
+
 ```
-opkg install lxc-auto
+I: Found additional required dependencies: fdisk libaudit-common libaudit1 libbz2-1.0 libcap-ng0 libdb5.3 libdebconfclient0 libgcrypt20 libgpg-error0 liblz4-1 libncursesw5 libsemanage-common libsemanage1 libsystemd0 libudev1
+I: Found additional base dependencies: dirmngr dmsetup gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libapparmor1 libassuan0 libbsd0 libcap2 libcryptsetup4 libdevmapper1.02.1 libdns-export190 libelf1 libfastjson4 libffi6 libgmp10 libgnutls30 libhogweed4 libidn11 libidn2-0 libip4tc0 libip6tc0 libiptc0 libisc-export189 libksba8 libldap-2.4-2 libldap-common liblocale-gettext-perl liblognorm5 libmnl0 libncurses5 libnetfilter-conntrack3 libnettle6 libnfnetlink0 libnpth0 libp11-kit0 libpsl5 libsasl2-2 libsasl2-modules-db libseccomp2 libsqlite3-0 libtasn1-6 libtext-charwidth-perl libtext-iconv-perl libtext-wrapi18n-perl libunistring2 libxtables12 openssl pinentry-curses xxd
+I: Checking component main on https://deb.debian.org/debian-ports...
+E: Couldn't find these debs: apt-transport-https
 ```
 
-a v souboru `/etc/config/lxc-auto` jen nastavíme jméno našeho kontejneru.
+**Řešení**:
+  * Počkat na opravený debootstrap
+  * Spustit debootstrap s parametrem--exclude=apt-transport-https
+  * V souboru: ''/usr/share/debootstrap/scripts/sid'' odstranit řádek 38 - konkrétně ''apt-transport-https''
+  * Použít: http://deb.debian.org/debian-ports/
+
+## Použití LXC kontejnerů
+
+  * Částečná izolace od hlavního systému a lepší migrovatelnost - klidně udělám factory reset Turrisu, aktualizuji jak chci, ale ten serverový kontejner je stále ve stejném stavu a po instalaci Turris OS stačí pouze pár příkazů pro opětovné integrování kontejneru do systému; tohle vidím jako velikou výhodu a už jsem změnil služby tak, že pod Turris OS jsou jen ty síťové věci a služby jsou v tom LXC Debianu
+  * Obecně tam jsou plné verze balíčků i základních knihoven a může být jednodušší používat balík v LXC Debianu, než se snažit kompilovat balík do OpenWRT
+  * Webový server s PHP 7, což se může hodit, pokud chcete provozovat moderní aplikace, nebo chcete využít výkonový boost ve verzi 7
+  * Snadno rozběháte Home Assistant v poslední verzi
+  * Snadno rozběháte cokoliv, co se kompiluje, protože přímo na Turrisu máte GCC ... i když to chvíli potrvá
 
 # Poznámky
 - Je možné provést debootstrap na PC a poté rootfs zkopírovat na Turris, což může být rychlejší. Zde se pracuje pouze na Turrisu kvůli jednoduchosti.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 Je potřeba mít vhodné uložiště pro kontejnery.
 
-Nejlepší je SSD nebo HDD připojené přes SATA (v miniPCIe řadiči), stále dobré je totéž připojené přes USB. 
+Nejlepší je SSD nebo HDD připojené přes SATA (v miniPCIe), stále dobré je totéž připojené přes USB. 
 Když není jiného zbytí, lze použít buď SD kartu (v nativním slotu pod RAM nebo v USB čtečce), nebo obyčejný flash disk v USB. 
 
-U flash disku, nebo SD karty je nutné počítat s možným brzkým opotřebením a pomalou odezvou.
+U flash disku nebo SD karty je nutné počítat s možným brzkým opotřebením a pomalou odezvou.
 
 **Interní NAND paměť Turrisu nelze použít už jen vzhledem ke kapacitě, dále proto, že po opotřebení nejde vyměnit.**
 
@@ -15,7 +15,7 @@ Kontejnery nelze na instalovat na uložiště ve formátu FAT. Je tedy nutné po
 
 ## Situace ohledně distribucí
 
-Vzhledem k architektuře procesoru v Turrisu (1.0 a 1.1) je bohužel výběr linuxových distribucí poměrně dost omezený a to na:
+Vzhledem k použitému **procesoru Freescale P2020** a jeho architektuře **powerpcse** v **Turrisu 1.0 a 1.1** je bohužel výběr linuxových distribucí poměrně dost omezený a to na:
 
 - OpenWRT,
 - Turris OS, 
@@ -41,6 +41,7 @@ Jak OpenWRT, tak Turris OS v kontejneru mají jistě svá využití, nicméně n
 2. Spustíme updater.sh, aby nám nainstaloval balíčky LXC
 
      ```
+     opkg update
      updater.sh
     ```
     
@@ -81,7 +82,7 @@ wget https://raw.githubusercontent.com/renekliment/turris-lxc-howto/master/confi
 vim ./config
 ```
 
-Nastavíme DNS server pro kontejner:
+**Nastavíme DNS server pro kontejner:**
 ```
 vim ./rootfs/etc/resolv.conf
 ```
@@ -93,7 +94,7 @@ a upravíme adresu `127.0.0.1` na IP Turrise (výchozí `192.168.1.1`)
 ```
 ln -s /mnt/disk/lxc-containers/debian1 /srv/lxc/debian1
 ```
-2. Upravíme cestu lxc.lxcpath v souboru /etc/lxc/lxc.conf
+2. Upravíme cestu lxc.lxcpath v souboru `/etc/lxc/lxc.conf`
 
 
 Kontejner spustíme a připojíme se k jeho konzoli:
@@ -110,7 +111,9 @@ V souboru **/etc/config/lxc-auto** nastavíme jméno našeho kontejneru podle [o
 
 ## Známé chyby
 
-Před pár dny se odstranil balík **apt-transport-https**
+Balík **apt-transport-https**
+
+Před pár dny se odstranil balík z repozitáře Debianu
 
 ```
 I: Found additional required dependencies: fdisk libaudit-common libaudit1 libbz2-1.0 libcap-ng0 libdb5.3 libdebconfclient0 libgcrypt20 libgpg-error0 liblz4-1 libncursesw5 libsemanage-common libsemanage1 libsystemd0 libudev1
@@ -121,9 +124,35 @@ E: Couldn't find these debs: apt-transport-https
 
 **Řešení**:
   * Počkat na opravený debootstrap
-  * Spustit debootstrap s parametrem--exclude=apt-transport-https
-  * V souboru: ''/usr/share/debootstrap/scripts/sid'' odstranit řádek 38 - konkrétně ''apt-transport-https''
-  * Použít: http://deb.debian.org/debian-ports/
+  * Spustit debootstrap s parametrem --exclude=apt-transport-https
+```
+debootstrap --include debian-ports --exclude=apt-transport-https -archive-keyring --arch=powerpcspe sid rootfs https://deb.debian.org/debian-ports
+```
+  * Spustit deboostrap ze serveru http://deb.debian.org/debian-ports
+```
+debootstrap --include debian-ports -archive-keyring --arch=powerpcspe sid rootfs http://deb.debian.org/debian-ports
+```
+  * V souboru: ''/usr/share/debootstrap/scripts/sid'' odstranit řádek 38 konkrétně ''apt-transport-https''
+  
+APT
+
+```
+E: could not load seccomp policy: Invalid argument - HttpMethod::Configuration (22: Invalid argument)
+E: could not load seccomp policy: Invalid argument - HttpMethod::Configuration (22: Invalid argument)
+Reading package lists... Done
+E: Method http has died unexpectedly!
+E: Sub-process http returned an error code (100)
+```
+
+**Řešení**:
+  * Počkat na novou verzi APT
+  * Downgrade z novější verze (1.6~alpha1) na starší, ale avšak funkční verzi 1.5~beta1
+```
+wget http://bloodkings.eu/uloziste/debian/apt_1.5~beta1_powerpcspe.deb
+wget http://bloodkings.eu/uloziste/debian/apt-utils_1.5~beta1_powerpcspe.deb
+dpkg -i apt_1.5~beta1_powerpcspe.deb
+dpkg -i apt-utils_1.5~beta1_powerpcspe.deb
+```
 
 ## Použití LXC kontejnerů
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ E: Sub-process http returned an error code (100)
 
 **Řešení**:
   * Počkat na novou verzi APT
-  * Downgrade z novější verze (1.6~alpha1) na starší, ale avšak funkční verzi 1.5~beta1
+  * Downgrade z novější verze 1.6-alpha1 na starší, ale avšak funkční verzi 1.5-beta1
 ```
 wget http://bloodkings.eu/uloziste/debian/apt_1.5~beta1_powerpcspe.deb
 wget http://bloodkings.eu/uloziste/debian/apt-utils_1.5~beta1_powerpcspe.deb

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Je potřeba mít vhodné uložiště pro kontejnery.
 
-Nejlepší je SSD, nebo HDD v SATA portu, stále dobré je totéž připojené přes USB. 
+Nejlepší je SSD nebo HDD připojené přes SATA (v miniPCIe řadiči), stále dobré je totéž připojené přes USB. 
 Když není jiného zbytí, lze použít buď SD kartu (v nativním slotu pod RAM nebo v USB čtečce), nebo obyčejný flash disk v USB. 
 
 U flash disku, nebo SD karty je nutné počítat s možným brzkým opotřebením a pomalou odezvou.
@@ -19,7 +19,7 @@ Vzhledem k architektuře procesoru v Turrisu (1.0 a 1.1) je bohužel výběr lin
 
 - OpenWRT,
 - Turris OS, 
-- a Debian PowerPCSPE, který je poměrně experimentální.
+- Debian PowerPCSPE, který je poměrně experimentální.
 
 Jak OpenWRT, tak Turris OS v kontejneru mají jistě svá využití, nicméně nejzajímavější je poslední možnost, která je rozebrána dále.
 
@@ -44,7 +44,7 @@ Jak OpenWRT, tak Turris OS v kontejneru mají jistě svá využití, nicméně n
      updater.sh
     ```
     
-3. Volitelná instalace textového editoru **vim** (pro upravování souborů lze také použít [WinSCP](https://winscp.net).
+3. Volitelná instalace textového editoru **vim** (pro upravování souborů lze také použít [WinSCP](https://winscp.net)).
 
     ```
     opkg install vim 
@@ -87,12 +87,7 @@ vim ./rootfs/etc/resolv.conf
 ```
 a upravíme adresu `127.0.0.1` na IP Turrise (výchozí `192.168.1.1`)
 
-Chceme, aby byl kontejner dostupný i v administračním rozhraní LuCI, odkud se dá také ovládat:
-```
-ln -s /mnt/disk/lxc-containers/debian1 /srv/lxc/debian1
-```
-
-Pokud chceme, aby byly kontejnery dostupné i v LuCI, kde s nimi můžeme manipulovat, tak jsou dvě možnosti:
+**Pokud chceme, aby byly kontejnery dostupné i v LuCI, kde s nimi můžeme manipulovat, tak jsou dvě možnosti:**
 
 1. Vytvoříme symlink
 ```


### PR DESCRIPTION
Přidáno: využití LXC kontejnerů, znamé chyby a místo textového editoru VIM lze použít WinSCP.
Úprava: úvodu, instalaci balíčků nyní řeší updater.

Podle Vašeho návodu, který spravuji a pokouším se udržovat aktuální v [komunitní dokumentaci Turris](https://www.turris.cz/doc/cs/public/lxc) hlavně díky [reakcím ve vlákně](https://forum.turris.cz/t/lxc-kontejnery-na-turris-verze-1-x/2517/48) na fóru Turrisu.

Z mnoha reakcí na fóru je vidět, že mnoho lidí používá Váš návod zde na Githubu a je potřeba ho aktualizovat. :-)